### PR TITLE
fix: resolve iOS deadlock and Dart layer violation

### DIFF
--- a/ios/Classes/LocationManager.swift
+++ b/ios/Classes/LocationManager.swift
@@ -20,6 +20,15 @@ class LocationManager: NSObject, CLLocationManagerDelegate {
     private var lastEmittedLocation: CLLocation?
     private var lastEmissionTime: Date?
 
+    /// Guards `isInBackground` for cross-thread reads/writes.
+    private let stateLock = NSLock()
+    /// Tracks whether the app is currently in the background.
+    ///
+    /// Written on the main thread via NotificationCenter; read on the
+    /// location callback thread under `stateLock` to avoid any
+    /// synchronous main-thread dispatch (which risks deadlock).
+    private var isInBackground: Bool = false
+
     weak var plugin: LiveLocationPlugin?
 
     init(
@@ -56,6 +65,40 @@ class LocationManager: NSObject, CLLocationManagerDelegate {
             locationManager.allowsBackgroundLocationUpdates = true
             locationManager.pausesLocationUpdatesAutomatically = false
         }
+
+        // Capture initial app state. setupLocationManager() is called from
+        // init(), which is invoked on the main thread via MethodChannel, so
+        // UIApplication.shared is safe to read here.
+        isInBackground = UIApplication.shared.applicationState == .background
+
+        // Observe app lifecycle transitions to keep isInBackground in sync.
+        // These notifications always fire on the main thread, so no lock is
+        // needed when writing inside the selectors.
+        let nc = NotificationCenter.default
+        nc.addObserver(
+            self,
+            selector: #selector(handleAppDidEnterBackground),
+            name: UIApplication.didEnterBackgroundNotification,
+            object: nil
+        )
+        nc.addObserver(
+            self,
+            selector: #selector(handleAppWillEnterForeground),
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
+    }
+
+    @objc private func handleAppDidEnterBackground() {
+        stateLock.lock()
+        isInBackground = true
+        stateLock.unlock()
+    }
+
+    @objc private func handleAppWillEnterForeground() {
+        stateLock.lock()
+        isInBackground = false
+        stateLock.unlock()
     }
 
     private func getAccuracyLevel(from accuracy: String) -> CLLocationAccuracy {
@@ -120,6 +163,7 @@ class LocationManager: NSObject, CLLocationManagerDelegate {
 
     func dispose() {
         stopTracking()
+        NotificationCenter.default.removeObserver(self)
     }
 
     // MARK: - CLLocationManagerDelegate
@@ -134,16 +178,14 @@ class LocationManager: NSObject, CLLocationManagerDelegate {
             // Apply time and distance filters
             if shouldEmitLocation(location) {
                 let locationMap = locationToMap(location)
-                
-                // Determine application state on the main thread
-                var isForeground = true
-                if Thread.isMainThread {
-                    isForeground = UIApplication.shared.applicationState != .background
-                } else {
-                    DispatchQueue.main.sync {
-                        isForeground = UIApplication.shared.applicationState != .background
-                    }
-                }
+
+                // Read the pre-computed background flag under lock.
+                // This avoids any main-thread dispatch from the location
+                // callback thread, eliminating the deadlock risk that
+                // DispatchQueue.main.sync would introduce.
+                stateLock.lock()
+                let isForeground = !isInBackground
+                stateLock.unlock()
 
                 if isForeground {
                     foregroundEventSink(locationMap)

--- a/lib/flutter_live_location.dart
+++ b/lib/flutter_live_location.dart
@@ -150,10 +150,27 @@ class LiveLocation {
     }
   }
 
-  /// Sets up listeners for platform events.
+  /// Wires the platform interface callbacks to this instance's stream controllers.
+  ///
+  /// The platform channel layer calls [onForegroundLocation] and
+  /// [onBackgroundLocation] when native events arrive. By setting these here —
+  /// in the public API layer — we keep the method channel layer free of any
+  /// reference to this class, eliminating the circular dependency.
   void _setupPlatformListeners() {
-    // Listen to foreground location updates from platform
-    // (Implementation connects to MethodChannel in platform_interface.dart)
+    _platform.onForegroundLocation = _onForegroundLocation;
+    _platform.onBackgroundLocation = _onBackgroundLocation;
+  }
+
+  void _onForegroundLocation(LocationUpdate location) {
+    if (_isDisposed) return;
+    _lastKnownLocation = location;
+    _foregroundStreamController.add(location);
+  }
+
+  void _onBackgroundLocation(LocationUpdate location) {
+    if (_isDisposed) return;
+    _lastKnownLocation = location;
+    _backgroundStreamController.add(location);
   }
 
   /// Called when a stream gets its first listener.
@@ -262,26 +279,6 @@ class LiveLocation {
     }
   }
 
-  /// Emits a location update to foreground stream.
-  ///
-  /// This is called by the platform implementation via the platform interface.
-  void emitForegroundLocation(LocationUpdate location) {
-    if (_isDisposed) return;
-
-    _lastKnownLocation = location;
-    _foregroundStreamController.add(location);
-  }
-
-  /// Emits a location update to background stream.
-  ///
-  /// This is called by the platform implementation via the platform interface.
-  void emitBackgroundLocation(LocationUpdate location) {
-    if (_isDisposed) return;
-
-    _lastKnownLocation = location;
-    _backgroundStreamController.add(location);
-  }
-
   /// Disposes the plugin and cleans up all resources.
   ///
   /// After calling dispose, the singleton is reset and [initialize] can be
@@ -306,6 +303,11 @@ class LiveLocation {
       // Close streams
       await _foregroundStreamController.close();
       await _backgroundStreamController.close();
+
+      // Detach callbacks before platform dispose so a stale reference to this
+      // instance cannot receive events after the singleton has been reset.
+      _platform.onForegroundLocation = null;
+      _platform.onBackgroundLocation = null;
 
       // Call platform dispose
       await _platform.dispose();

--- a/lib/live_location_method_channel.dart
+++ b/lib/live_location_method_channel.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
-import 'flutter_live_location.dart';
+import 'exceptions/location_exceptions.dart';
 import 'live_location_platform_interface.dart';
+import 'models/location_config.dart';
+import 'models/location_update.dart';
 
 /// MethodChannel implementation of LiveLocationPlatform.
 ///
@@ -81,12 +83,17 @@ class MethodChannelLiveLocation extends LiveLocationPlatform {
   }
 
   /// Sets up listeners for EventChannels from native platform.
+  ///
+  /// Parsed [LocationUpdate] objects are delivered via the
+  /// [onForegroundLocation] and [onBackgroundLocation] callbacks set on the
+  /// platform interface by the public API layer. This keeps the method channel
+  /// layer decoupled from the public API singleton.
   void _setupEventChannels() {
     foregroundEventChannel.receiveBroadcastStream().listen(
       (dynamic event) {
         try {
           final location = _locationFromMap(event as Map<dynamic, dynamic>);
-          LiveLocation.instance.emitForegroundLocation(location);
+          onForegroundLocation?.call(location);
         } catch (e) {
           debugPrint('Error parsing foreground location: $e');
         }
@@ -100,7 +107,7 @@ class MethodChannelLiveLocation extends LiveLocationPlatform {
       (dynamic event) {
         try {
           final location = _locationFromMap(event as Map<dynamic, dynamic>);
-          LiveLocation.instance.emitBackgroundLocation(location);
+          onBackgroundLocation?.call(location);
         } catch (e) {
           debugPrint('Error parsing background location: $e');
         }

--- a/lib/live_location_platform_interface.dart
+++ b/lib/live_location_platform_interface.dart
@@ -2,6 +2,7 @@ import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import 'live_location_method_channel.dart';
 import 'models/location_config.dart';
+import 'models/location_update.dart';
 
 /// Abstract platform interface for live location tracking.
 ///
@@ -27,6 +28,28 @@ abstract class LiveLocationPlatform extends PlatformInterface {
     PlatformInterface.verifyToken(instance, _token);
     _instance = instance;
   }
+
+  // ---------------------------------------------------------------------------
+  // Upward data callbacks
+  //
+  // Set by the public API layer (LiveLocation) during initialization so that
+  // the platform channel layer can push location events upward without
+  // importing or referencing the public API class.
+  // ---------------------------------------------------------------------------
+
+  /// Invoked by the platform channel layer when a foreground location arrives.
+  ///
+  /// The public API layer sets this during [initialize] via
+  /// [LiveLocation._setupPlatformListeners]. Platform implementations must
+  /// call this instead of reaching directly into the public API singleton.
+  void Function(LocationUpdate)? onForegroundLocation;
+
+  /// Invoked by the platform channel layer when a background location arrives.
+  ///
+  /// The public API layer sets this during [initialize] via
+  /// [LiveLocation._setupPlatformListeners]. Platform implementations must
+  /// call this instead of reaching directly into the public API singleton.
+  void Function(LocationUpdate)? onBackgroundLocation;
 
   /// Initializes the platform-specific implementation.
   ///

--- a/test/live_location_test.dart
+++ b/test/live_location_test.dart
@@ -8,6 +8,12 @@ class MockLiveLocationPlatform
     with MockPlatformInterfaceMixin
     implements LiveLocationPlatform {
   @override
+  void Function(LocationUpdate)? onForegroundLocation;
+
+  @override
+  void Function(LocationUpdate)? onBackgroundLocation;
+
+  @override
   Future<void> initialize({required LocationConfig config}) => Future.value();
 
   @override

--- a/test/location_stream_permission_test.dart
+++ b/test/location_stream_permission_test.dart
@@ -23,6 +23,12 @@ class _SuccessMockPlatform
     with MockPlatformInterfaceMixin
     implements LiveLocationPlatform {
   @override
+  void Function(LocationUpdate)? onForegroundLocation;
+
+  @override
+  void Function(LocationUpdate)? onBackgroundLocation;
+
+  @override
   Future<void> initialize({required LocationConfig config}) => Future.value();
 
   @override
@@ -48,6 +54,12 @@ class _SuccessMockPlatform
 class _PermissionDeniedMockPlatform
     with MockPlatformInterfaceMixin
     implements LiveLocationPlatform {
+  @override
+  void Function(LocationUpdate)? onForegroundLocation;
+
+  @override
+  void Function(LocationUpdate)? onBackgroundLocation;
+
   @override
   Future<void> initialize({required LocationConfig config}) => Future.value();
 
@@ -117,7 +129,7 @@ void main() {
       final sub =
           LiveLocation.instance.foregroundLocationStream.listen(received.add);
 
-      LiveLocation.instance.emitForegroundLocation(_foregroundUpdate);
+      LiveLocationPlatform.instance.onForegroundLocation?.call(_foregroundUpdate);
       await Future.microtask(() {});
 
       expect(received, hasLength(1));
@@ -138,7 +150,7 @@ void main() {
       final sub2 =
           LiveLocation.instance.foregroundLocationStream.listen(second.add);
 
-      LiveLocation.instance.emitForegroundLocation(_foregroundUpdate);
+      LiveLocationPlatform.instance.onForegroundLocation?.call(_foregroundUpdate);
       await Future.microtask(() {});
 
       expect(first, hasLength(1));
@@ -153,7 +165,7 @@ void main() {
 
       expect(LiveLocation.instance.lastKnownLocation, isNull);
 
-      LiveLocation.instance.emitForegroundLocation(_foregroundUpdate);
+      LiveLocationPlatform.instance.onForegroundLocation?.call(_foregroundUpdate);
       await Future.microtask(() {});
 
       expect(
@@ -188,7 +200,7 @@ void main() {
       final sub =
           LiveLocation.instance.backgroundLocationStream.listen(received.add);
 
-      LiveLocation.instance.emitBackgroundLocation(_backgroundUpdate);
+      LiveLocationPlatform.instance.onBackgroundLocation?.call(_backgroundUpdate);
       await Future.microtask(() {});
 
       expect(received, hasLength(1));
@@ -201,7 +213,7 @@ void main() {
     test('caches the last background update in lastKnownLocation', () async {
       await LiveLocation.initialize(config: _config(background: true));
 
-      LiveLocation.instance.emitBackgroundLocation(_backgroundUpdate);
+      LiveLocationPlatform.instance.onBackgroundLocation?.call(_backgroundUpdate);
       await Future.microtask(() {});
 
       expect(
@@ -215,8 +227,8 @@ void main() {
       () async {
         await LiveLocation.initialize(config: _config(background: true));
 
-        LiveLocation.instance.emitForegroundLocation(_foregroundUpdate);
-        LiveLocation.instance.emitBackgroundLocation(_backgroundUpdate);
+        LiveLocationPlatform.instance.onForegroundLocation?.call(_foregroundUpdate);
+        LiveLocationPlatform.instance.onBackgroundLocation?.call(_backgroundUpdate);
         await Future.microtask(() {});
 
         // The most recent emission wins.


### PR DESCRIPTION
## iOS - DispatchQueue.main.sync deadlock (LocationManager.swift) CLLocationManager delegate callbacks arrive on a background thread. The previous code used DispatchQueue.main.sync to read UIApplication applicationState, which blocks the callback thread until the main thread is free — a classic deadlock condition.

Fix: track foreground/background state via NotificationCenter observers (didEnterBackgroundNotification / willEnterForegroundNotification), which always fire on the main thread. Store the state in isInBackground guarded by NSLock, and read it directly in the location callback with a lock acquire/release — no main-thread dispatch in the hot path at all. NotificationCenter observers are removed in dispose() to prevent post-teardown callbacks on a dead instance.

## Dart - empty _setupPlatformListeners() stub + circular layer violation MethodChannelLiveLocation (platform channel layer) was calling LiveLocation.instance.emitForegroundLocation() and emitBackgroundLocation() — a lower layer reaching up into the public API singleton, creating a circular import and breaking the strict layer contract.

Fix: add onForegroundLocation and onBackgroundLocation callback properties to LiveLocationPlatform (the interface layer). The public API layer sets these during _setupPlatformListeners() (now fully implemented). The method channel layer calls the callbacks instead of referencing LiveLocation. The circular import from live_location_method_channel.dart is removed. Public emitForegroundLocation/emitBackgroundLocation methods are removed; private _onForegroundLocation/_onBackgroundLocation handlers replace them. Callbacks are nulled in dispose() to prevent stale-instance retention.

## Tests
Mock platform classes updated with the two new callback fields required by the implements contract. Test emit call-sites updated to invoke the callbacks directly (LiveLocationPlatform.instance.onForegroundLocation?.call), which now exercises the full wiring end-to-end rather than bypassing it. All 18 tests pass, zero analyzer warnings.